### PR TITLE
Update contributors link to reference this repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,7 +87,7 @@
   Written Kitten was created by <a href="http://twitter.com/Skud"
   rel="author">Skud</a>, <a href="http://twitter.com/aquaprofundanet"
   rel="author">Emily</a> and <a
-  href="https://github.com/Skud/writtenkitten/blob/master/CONTRIBUTORS.md">contributors</a> and is now managed by <a href="http://twitter.com/josh_walcher">Josh</a> and hosted by <a href="http://www.bigboardroom.com/services/hosting/">BigBoardroom</a>.
+  href="https://github.com/joshuawalcher/writtenkitten/blob/master/CONTRIBUTORS.md">contributors</a> and is now managed by <a href="http://twitter.com/josh_walcher">Josh</a> and hosted by <a href="http://www.bigboardroom.com/services/hosting/">BigBoardroom</a>.
   </p>
   <p>
   Images are randomly selected from Flickr&apos;s &ldquo;most


### PR DESCRIPTION
Resolves #7.  Referencing this repository will allow us to maintain our own / separate list of contributors while respecting the original contributors (which we'll of course leave in the file).