### PR TITLE
Fix permanent strikeout

### DIFF
--- a/WrittenKitten.js
+++ b/WrittenKitten.js
@@ -162,6 +162,10 @@
 			$("#titleKitten").html("<strike>Kitten!</strike>");
 			$("#titleSearch").html("&nbsp;" + search_for.replace(',cute','') + "!");
 		}
+		else {
+			$("#titleKitten").html("Kitten!");
+			$("#titleSearch").html("");
+		}
 	}
 	
 	function getParameterByName(name) {


### PR DESCRIPTION
Hey! I noticed that the strikeout over the word "Kitten!" when users select "puppy" or "bunny" wasn't going away when users select "Kitten" again. It should be a very minor fix, and it doesn't seem to affect the functionality of the application, but it would make the page a little cleaner.

(This is my first pull request, so please let me know if I'm breaking any standard protocol! Great app!)