### PR TITLE
Filter out results that are tagged as `ai`

### DIFF
--- a/WrittenKitten.js
+++ b/WrittenKitten.js
@@ -115,7 +115,7 @@
 			flickr_search_term = search_for;
 		}
 	
-		var flickr_url = "https://api.flickr.com/services/rest/?api_key=0fa41c7f9709b1d850756011e09bbef6&format=json&sort=interestingness-desc&method=flickr.photos.search&license=" + valid_licenses + "&extras=owner_name,license&tags=" + flickr_search_term + "&tag_mode=all&jsoncallback=?";
+		var flickr_url = "https://api.flickr.com/services/rest/?api_key=0fa41c7f9709b1d850756011e09bbef6&format=json&sort=interestingness-desc&method=flickr.photos.search&license=" + valid_licenses + "&extras=owner_name,license&tags=-ai," + flickr_search_term + "&tag_mode=all&jsoncallback=?";
 	
 		$.getJSON(flickr_url, function(data) {
 			if (data.stat == "ok") {


### PR DESCRIPTION
Recently a user sebilden has been posting a *lot* of AI artwork with the tags `cat` and `cute` ([example](https://www.flickr.com/photos/81677556@N00/52582929769)), polluting the images displayed by Written Kitten to the point where the majority of images being displayed are by this user.

This fix filters the tag `ai` from the query and will resolve this issue.